### PR TITLE
Added IP Address Server configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,17 @@ Link-local:
     - 169.254.%
 ```
 
+### IP Address Server
+
+Some organisations may not be keen on Munkireport using [ipify](https://ipify.org), as it is also commonly used by malware. You can specify a custom server for getting a clients public IP using Munkireport's global preferences with the `IpAddressServer` key:
+```bash
+defaults write /Library/Preferences/MunkiReport.plist IpAddressServer 'https://myserver.example/'
+```
+
+This custom server should return only an IP address in response to a curl request. You can see an example of what this module expects with the following command:
+```bash
+curl -s https://api.ipify.org
+```
 
 Table Schema
 -----

--- a/scripts/networkinfo.py
+++ b/scripts/networkinfo.py
@@ -8,6 +8,8 @@ import plistlib
 import socket, struct
 import re
 
+from Foundation import CFPreferencesCopyAppValue
+
 def get_network_info():
     '''Uses system profiler to get info about the network'''
     output = bashCommand(['/usr/sbin/system_profiler', 'SPNetworkDataType', '-xml'])
@@ -187,8 +189,12 @@ def get_additional_info(interface):
     return network
         
 def get_external_ip():
-    
-    cmd = ['/usr/bin/curl', '--connect-timeout', '5', 'https://api.ipify.org']
+    ip_address_server = str(get_pref_value('IpAddressServer', 'MunkiReport'))
+
+    if len(ip_address_server) == 0:
+        ip_address_server = "https://api.ipify.org"
+
+    cmd = ['/usr/bin/curl', '--connect-timeout', '5', ip_address_server]
     proc = subprocess.Popen(cmd, shell=False, bufsize=-1,
                             stdin=subprocess.PIPE,
                             stdout=subprocess.PIPE, stderr=subprocess.PIPE)


### PR DESCRIPTION
This PR adds the ability to specify the URL of an IP address server to use via the `IpAddressServer` configuration key on the client. 

As a result, organisations who may not wish to send requests to [ipify](https://ipify.org) can set up their own IP address servers, and configure their clients to use these instead.